### PR TITLE
Ansible Roles

### DIFF
--- a/ansible_roles/README.md
+++ b/ansible_roles/README.md
@@ -1,0 +1,87 @@
+# 🛠️ Ansible Role-Based Web Server Setup
+
+This Ansible project demonstrates a structured, role-based approach to setting up web servers using **nginx** and **apache2**. It highlights role separation, task modularization, and discusses a real-world issue of port conflict between web servers.
+
+---
+
+## ✅ Task Flow and Execution Order
+
+### 🔹 `ansible_roles.yml` (Playbook entry point)
+- Executes roles in order:
+  1. **custom-role**
+  2. **install-apache**
+
+---
+
+### 🔹 `custom-role` Role
+
+#### 1. `tasks/main.yml`
+- Includes subtasks:
+  - `packages.yml`
+  - `message.yml`
+
+#### 2. `tasks/packages.yml`
+- Installs `nginx` web server and prints a debug message.
+
+#### 3. `tasks/message.yml`
+- Reads a variable from `vars/main.yml` and prints a custom message.
+
+#### 4. `vars/main.yml`
+- Defines variables like `message` used in tasks.
+
+---
+
+### 🔹 `install-apache` Role
+
+#### 1. `tasks/main.yml`
+- Installs and attempts to start the `apache2` web server service.
+
+---
+
+## ⚠️ Port Conflict: Apache2 vs Nginx
+
+Both **nginx** and **apache2** default to **port 80**, which causes a conflict if both are started simultaneously.
+
+### ❌ Error Example:
+
+```bash
+fatal: [localhost]: FAILED! => {"msg": "Could not find the requested service lighttpd: host"}
+```
+
+(OR)
+
+``` bash
+Job for apache2.service failed because the control process exited with error code.
+```
+
+---
+
+### ✅ Solution: Change Apache2 Port
+##### Can change either of Apache2 (OR) Nginx 
+
+🔧 Edit Apache2 Port:
+``` bash
+sudo nano /etc/apache2/ports.conf
+```
+
+Change:
+``` bash
+Listen 80
+```
+
+to:
+
+``` bash
+Listen 8080
+```
+
+---
+
+### 🔄 Restart Apache2:
+``` bash
+sudo systemctl restart apache2
+```
+
+This ensures both nginx and apache2 can run simultaneously without port conflict.
+
+---

--- a/ansible_roles/ansible_roles.yml
+++ b/ansible_roles/ansible_roles.yml
@@ -1,0 +1,9 @@
+---
+- name: Ansible Roles Example
+  hosts: all
+  become: yes
+  remote_user: ubuntu
+
+  roles:
+    - custom-role
+    - install-apache

--- a/ansible_roles/inventory/ansible_roles/hosts
+++ b/ansible_roles/inventory/ansible_roles/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible_roles/roles/custom-role/tasks/main.yml
+++ b/ansible_roles/roles/custom-role/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- import_tasks: packages.yml
+- import_tasks: message.yml
+
+- name: Start nginx service
+  service:
+    name: nginx
+    state: started

--- a/ansible_roles/roles/custom-role/tasks/message.yml
+++ b/ansible_roles/roles/custom-role/tasks/message.yml
@@ -1,0 +1,5 @@
+---
+- name: Set message file
+  copy:
+    content: "{{ message }}"
+    dest: /var/www/html/index.html

--- a/ansible_roles/roles/custom-role/tasks/packages.yml
+++ b/ansible_roles/roles/custom-role/tasks/packages.yml
@@ -1,0 +1,9 @@
+---
+- name: Install required packages
+  apt:
+    name:
+      - nginx
+      - git
+      - curl
+    state: latest
+    update_cache: yes

--- a/ansible_roles/roles/custom-role/vars/main.yml
+++ b/ansible_roles/roles/custom-role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+message: "Hello, World! This is a custom message."

--- a/ansible_roles/roles/install-apache/tasks/main.yml
+++ b/ansible_roles/roles/install-apache/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install Apache Web Server
+  apt:
+    name: apache2
+    state: latest
+    update_cache: yes
+
+- name: Start Apache Service
+  service:
+    name: apache2
+    state: started
+    enabled: yes


### PR DESCRIPTION
This playbook configures the system using two roles:

- custom: Handles initial setup steps like updating packages and setting up hostname.
- apache: Manages Apache2 installation, configuration, and service start.

Each role contains structured subtasks for modular and clear execution.